### PR TITLE
Check for a divide by zero in the step calculation

### DIFF
--- a/seamoptimizer.h
+++ b/seamoptimizer.h
@@ -466,6 +466,10 @@ static void so_seams_add_seam(so_seam_t **seams, so_vec2 a0, so_vec2 a1, so_vec2
 	int iterations = (int)(l * 5.0f); // TODO: is this the best value?
 	float step = 1.0f / iterations;
 
+	if (iterations == 0) {
+		step = 0.0;
+	}
+
 	so_seam_t currentSeam = {0};
 	currentSeam.x_min = w; currentSeam.y_min = h;
 	currentSeam.x_max = 0; currentSeam.y_max = 0;


### PR DESCRIPTION
Hi, thanks for the great library! I'm still evaluating if it'll work for my needs but I managed to find one SEGFAULT along the way. 

```c
float l = so_length2(ad);
int iterations = (int)(l * 5.0f); // TODO: is this the best value?
float step = 1.0f / iterations;
```
with this code, if `l` is below `0.2` (`0.1995` or so in my case) then the number of iterations will be 0 and step will be `nan`, which breaks things down the chain and ends up with an attempt to read an out of bounds value from the lightmap.